### PR TITLE
Allow to change the kernel host and port

### DIFF
--- a/cmd/kernel/main.go
+++ b/cmd/kernel/main.go
@@ -44,7 +44,12 @@ func main() {
 	var vertex *exec.Cmd
 	go func() {
 		var err error
-		vertex, err = runVertex()
+		vertex, err = runVertex([]string{
+			"-port", config.KernelCurrent.PortVertex,
+			"-host", config.KernelCurrent.HostVertex,
+			"-host-kernel", config.KernelCurrent.HostKernel,
+			"-port-kernel", config.KernelCurrent.PortKernel,
+		}...)
 		if err != nil {
 			log.Error(err)
 			shutdownChan <- syscall.SIGINT
@@ -81,13 +86,18 @@ func parseArgs() {
 	flagGID := flag.Uint("gid", 0, "gid of the unprivileged user")
 
 	// Copy/paste from cmd/main/main.go
-	flagPort := flag.String("port", config.Current.Port, "The Vertex port")
-	flagHost := flag.String("host", config.Current.Host, "The Vertex access url")
+	flagPort := flag.String("port", config.Current.PortVertex, "The Vertex port")
+	flagHost := flag.String("host", config.Current.HostVertex, "The Vertex access url")
+
+	flagHostKernel := flag.String("host-kernel", config.Current.HostKernel, "The Vertex Kernel access url")
+	flagPortKernel := flag.String("port-kernel", config.Current.PortKernel, "The Vertex Kernel port")
 
 	flag.Parse()
 
-	config.Current.Host = *flagHost
-	config.Current.Port = *flagPort
+	config.KernelCurrent.HostVertex = *flagHost
+	config.KernelCurrent.PortVertex = *flagPort
+	config.KernelCurrent.HostKernel = *flagHostKernel
+	config.KernelCurrent.PortKernel = *flagPortKernel
 
 	if *flagUsername != "" {
 		u, err := user.Lookup(*flagUsername)

--- a/cmd/kernel/runner.go
+++ b/cmd/kernel/runner.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vertex-center/vlog"
 )
 
-func runVertex() (*exec.Cmd, error) {
+func runVertex(args ...string) (*exec.Cmd, error) {
 	uid, gid := config.KernelCurrent.Uid, config.KernelCurrent.Gid
 
 	log.Info("running vertex",
@@ -20,7 +20,7 @@ func runVertex() (*exec.Cmd, error) {
 		vlog.Uint32("gid", gid),
 	)
 
-	cmd := exec.Command("./vertex", "-port", config.Current.Port, "-host", config.Current.Host)
+	cmd := exec.Command("./vertex", args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
 	cmd.Stdout = os.Stdout

--- a/cmd/kernel/runner_windows.go
+++ b/cmd/kernel/runner_windows.go
@@ -5,12 +5,10 @@ package main
 import (
 	"os"
 	"os/exec"
-
-	"github.com/vertex-center/vertex/config"
 )
 
-func runVertex() (*exec.Cmd, error) {
-	cmd := exec.Command("vertex.exe", "-port", config.Current.Port, "-host", config.Current.Host)
+func runVertex(args ...string) (*exec.Cmd, error) {
+	cmd := exec.Command("vertex.exe", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -63,10 +63,10 @@ func main() {
 	}()
 
 	// Logs
-	url := fmt.Sprintf("http://%s", config.Current.Host)
+	url := fmt.Sprintf("http://%s", config.Current.HostVertex)
 	fmt.Printf("\n-- Vertex Client :: %s\n\n", url)
 
-	r.Start(fmt.Sprintf(":%s", config.Current.Port))
+	r.Start(fmt.Sprintf(":%s", config.Current.PortVertex))
 }
 
 func parseArgs() {
@@ -75,8 +75,11 @@ func parseArgs() {
 	flagDate := flag.Bool("date", false, "Print the release date")
 	flagCommit := flag.Bool("commit", false, "Print the commit hash")
 
-	flagPort := flag.String("port", config.Current.Port, "The Vertex port")
-	flagHost := flag.String("host", config.Current.Host, "The Vertex access url")
+	flagPort := flag.String("port", config.Current.PortVertex, "The Vertex port")
+	flagHost := flag.String("host", config.Current.HostVertex, "The Vertex access url")
+
+	flagHostKernel := flag.String("host-kernel", config.Current.HostKernel, "The Vertex Kernel access url")
+	flagPortKernel := flag.String("port-kernel", config.Current.PortKernel, "The Vertex Kernel port")
 
 	flag.Parse()
 
@@ -92,8 +95,10 @@ func parseArgs() {
 		fmt.Println(commit)
 		os.Exit(0)
 	}
-	config.Current.Host = *flagHost
-	config.Current.Port = *flagPort
+	config.Current.HostVertex = *flagHost
+	config.Current.PortVertex = *flagPort
+	config.Current.HostKernel = *flagHostKernel
+	config.Current.PortKernel = *flagPortKernel
 }
 
 func checkNotRoot() {

--- a/config/config.go
+++ b/config/config.go
@@ -11,18 +11,24 @@ import (
 var Current = New()
 
 type Config struct {
-	Host string `json:"host"`
-	Port string `json:"port"`
+	HostVertex string `json:"host"`
+	PortVertex string `json:"port"`
+
+	HostKernel string `json:"host_kernel"`
+	PortKernel string `json:"port_kernel"`
 }
 
 func New() Config {
 	return Config{
-		Host: "127.0.0.1:6130",
-		Port: "6130",
+		HostVertex: "127.0.0.1:6130",
+		PortVertex: "6130",
+
+		HostKernel: "http://localhost:6131",
+		PortKernel: "6131",
 	}
 }
 
 func (c Config) Apply() error {
-	configJsContent := fmt.Sprintf("window.apiURL = \"http://%s\";", c.Host)
+	configJsContent := fmt.Sprintf("window.apiURL = \"http://%s\";", c.HostVertex)
 	return os.WriteFile(path.Join(storage.Path, "client", "dist", "config.js"), []byte(configJsContent), os.ModePerm)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -89,7 +89,7 @@ func (r *Router) Start(addr string) {
 		log.Error(err)
 	}
 
-	url := fmt.Sprintf("http://%s", config.Current.Host)
+	url := fmt.Sprintf("http://%s", config.Current.HostVertex)
 	log.Info("Vertex started",
 		vlog.String("url", url),
 	)

--- a/router/router_kernel.go
+++ b/router/router_kernel.go
@@ -2,11 +2,13 @@ package router
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/vertex-center/vertex/adapter"
+	"github.com/vertex-center/vertex/config"
 	"github.com/vertex-center/vertex/pkg/ginutils"
 	"github.com/vertex-center/vertex/pkg/log"
 	"github.com/vertex-center/vertex/services"
@@ -47,13 +49,12 @@ func NewKernelRouter() KernelRouter {
 
 func (r *KernelRouter) Start() error {
 	r.server = &http.Server{
-		Addr:    ":6131",
+		Addr:    fmt.Sprintf(":%s", config.KernelCurrent.PortKernel),
 		Handler: r.engine,
 	}
 
-	url := "http://localhost:6131"
 	log.Info("vertex-kernel started",
-		vlog.String("url", url),
+		vlog.String("url", config.KernelCurrent.HostKernel),
 	)
 
 	return r.server.ListenAndServe()

--- a/services/instance.go
+++ b/services/instance.go
@@ -499,7 +499,7 @@ func (s *InstanceService) remapDatabaseEnv(uuid uuid.UUID) error {
 			return err
 		}
 
-		host := config.Current.Host
+		host := config.Current.HostVertex
 		if strings.Contains(host, ":") {
 			host, _, err = net.SplitHostPort(host)
 			if err != nil {

--- a/services/ssh.go
+++ b/services/ssh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/carlmjohnson/requests"
+	"github.com/vertex-center/vertex/config"
 	"github.com/vertex-center/vertex/types"
 )
 
@@ -16,21 +17,23 @@ func NewSSHService() SSHService {
 
 func (s *SSHService) GetAll() ([]types.PublicKey, error) {
 	var keys []types.PublicKey
-	err := requests.URL("http://localhost:6131/api/security/ssh").
+	err := requests.URL(config.Current.HostKernel).
+		Path("/api/security/ssh").
 		ToJSON(&keys).
 		Fetch(context.Background())
 	return keys, err
 }
 
 func (s *SSHService) Add(key string) error {
-	return requests.URL("http://localhost:6131/api/security/ssh").
+	return requests.URL(config.Current.HostKernel).
+		Path("/api/security/ssh").
 		Post().
 		BodyBytes([]byte(key)).
 		Fetch(context.Background())
 }
 
 func (s *SSHService) Delete(fingerprint string) error {
-	return requests.URL("http://localhost:6131/").
+	return requests.URL(config.Current.HostKernel).
 		Pathf("/api/security/ssh/%s", fingerprint).
 		Delete().
 		Fetch(context.Background())


### PR DESCRIPTION
Allow to change the kernel host and port with `--kernel-host` and `--kernel-port`.

This also fixes a code smell where the kernel url was hardcoded in the code.