### PR TITLE
Create a migration tool

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -8,7 +8,9 @@ import (
 	"runtime"
 
 	"github.com/vertex-center/vertex/config"
+	"github.com/vertex-center/vertex/migration"
 	"github.com/vertex-center/vertex/pkg/log"
+	"github.com/vertex-center/vertex/pkg/storage"
 	"github.com/vertex-center/vertex/router"
 	"github.com/vertex-center/vertex/services"
 	"github.com/vertex-center/vertex/types"
@@ -26,11 +28,16 @@ func main() {
 
 	log.Info("Vertex starting...")
 
+	err := migration.NewMigrationTool(storage.Path).Migrate()
+	if err != nil {
+		panic(err)
+	}
+
 	parseArgs()
 
 	checkNotRoot()
 
-	err := setupDependencies()
+	err = setupDependencies()
 	if err != nil {
 		log.Error(fmt.Errorf("failed to setup dependencies: %v", err))
 		return

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -1,0 +1,94 @@
+package migration
+
+import (
+	"os"
+	"path"
+
+	"github.com/vertex-center/vertex/pkg/log"
+	"github.com/vertex-center/vlog"
+	"gopkg.in/yaml.v3"
+)
+
+type MigrationTool struct {
+	livePath     string
+	metadataPath string
+	migrations   []Migration
+}
+
+type LiveVersion struct {
+	Version int
+}
+
+type Migration interface {
+	Up(livePath string) error
+	Down(livePath string) error
+}
+
+func NewMigrationTool(livePath string) *MigrationTool {
+	return &MigrationTool{
+		livePath:     livePath,
+		metadataPath: path.Join(livePath, "metadata.yml"),
+		migrations:   []Migration{
+			// Add migrations here
+		},
+	}
+}
+
+func (t *MigrationTool) Migrate() error {
+	v, err := t.readLiveVersion()
+	if err != nil {
+		return err
+	}
+
+	for i := v.Version + 1; i < len(t.migrations); i++ {
+		log.Info("running migration", vlog.Int("version", i))
+		err := t.migrations[i].Up(t.livePath)
+		if err != nil {
+			return err
+		}
+
+		v.Version = i
+		err = t.writeLiveVersion(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *MigrationTool) readLiveVersion() (*LiveVersion, error) {
+	b, err := os.ReadFile(t.metadataPath)
+	if err != nil && os.IsNotExist(err) {
+		err := t.writeLiveVersion(&LiveVersion{Version: -1})
+		if err != nil {
+			return nil, err
+		}
+		return &LiveVersion{Version: -1}, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	var v LiveVersion
+	err = yaml.Unmarshal(b, &v)
+	return &v, err
+}
+
+func (t *MigrationTool) writeLiveVersion(v *LiveVersion) error {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(t.metadataPath, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(b)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -1,0 +1,44 @@
+package migration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type MigrationTestSuite struct {
+	suite.Suite
+
+	tool *MigrationTool
+}
+
+func TestMigrationTestSuite(t *testing.T) {
+	suite.Run(t, new(MigrationTestSuite))
+}
+
+func (suite *MigrationTestSuite) SetupTest() {
+	dir, err := os.MkdirTemp("", "live_temp-*")
+	if err != nil {
+		return
+	}
+
+	suite.tool = NewMigrationTool(dir)
+}
+
+func (suite *MigrationTestSuite) TearDownTest() {
+	err := os.RemoveAll(suite.tool.livePath)
+	suite.NoError(err)
+}
+
+func (suite *MigrationTestSuite) TestMigrate() {
+	err := suite.tool.Migrate()
+	suite.NoError(err)
+
+	_, err = os.Stat(suite.tool.metadataPath)
+	suite.NoError(err)
+
+	v, err := suite.tool.readLiveVersion()
+	suite.NoError(err)
+	suite.Equal(len(suite.tool.migrations)-1, v.Version)
+}


### PR DESCRIPTION
This PR closes #41. The migration tool will be able to migrate the live folder between versions.