### PR TITLE
Feat: Add custom database name support

### DIFF
--- a/apps/containers/adapter/container_env_fs.go
+++ b/apps/containers/adapter/container_env_fs.go
@@ -46,6 +46,11 @@ func (a *ContainerEnvFSAdapter) Save(uuid uuid.UUID, env containerstypes.Contain
 		return err
 	}
 
+	err = file.Truncate(0)
+	if err != nil {
+		return err
+	}
+
 	for key, value := range env {
 		_, err := file.WriteString(strings.Join([]string{key, value}, "=") + "\n")
 		if err != nil {

--- a/apps/containers/core/port/services.go
+++ b/apps/containers/core/port/services.go
@@ -20,7 +20,7 @@ type (
 		DeleteAll()
 		Install(service types.Service, method string) (*types.Container, error)
 		CheckForUpdates() (map[uuid.UUID]*types.Container, error)
-		SetDatabases(inst *types.Container, databases map[string]uuid.UUID, modifiedFeature map[string]*types.DatabaseFeature) error
+		SetDatabases(inst *types.Container, databases map[string]uuid.UUID, options map[string]*types.SetDatabasesOptions) error
 	}
 
 	ContainerEnvService interface {

--- a/apps/containers/core/port/services.go
+++ b/apps/containers/core/port/services.go
@@ -20,7 +20,7 @@ type (
 		DeleteAll()
 		Install(service types.Service, method string) (*types.Container, error)
 		CheckForUpdates() (map[uuid.UUID]*types.Container, error)
-		SetDatabases(inst *types.Container, databases map[string]uuid.UUID) error
+		SetDatabases(inst *types.Container, databases map[string]uuid.UUID, modifiedFeature map[string]*types.DatabaseFeature) error
 	}
 
 	ContainerEnvService interface {

--- a/apps/containers/core/service/container.go
+++ b/apps/containers/core/service/container.go
@@ -361,7 +361,7 @@ func (s *ContainerService) load(uuid uuid.UUID) error {
 	return nil
 }
 
-func (s *ContainerService) SetDatabases(inst *types.Container, databases map[string]uuid.UUID, modifiedFeature map[string]*types.DatabaseFeature) error {
+func (s *ContainerService) SetDatabases(inst *types.Container, databases map[string]uuid.UUID, options map[string]*types.SetDatabasesOptions) error {
 	for db := range databases {
 		if _, ok := inst.Service.Databases[db]; !ok {
 			return types.ErrDatabaseIDNotFound
@@ -373,11 +373,11 @@ func (s *ContainerService) SetDatabases(inst *types.Container, databases map[str
 	if err != nil {
 		return err
 	}
-	return s.remapDatabaseEnv(inst, modifiedFeature)
+	return s.remapDatabaseEnv(inst, options)
 }
 
 // remapDatabaseEnv remaps the environment variables of an container.
-func (s *ContainerService) remapDatabaseEnv(inst *types.Container, modifiedFeatures map[string]*types.DatabaseFeature) error {
+func (s *ContainerService) remapDatabaseEnv(inst *types.Container, options map[string]*types.SetDatabasesOptions) error {
 	for databaseID, databaseContainerUUID := range inst.Databases {
 		db, err := s.Get(databaseContainerUUID)
 		if err != nil {
@@ -398,10 +398,10 @@ func (s *ContainerService) remapDatabaseEnv(inst *types.Container, modifiedFeatu
 			inst.Env[iEnvNames.Password] = db.Env[*dbEnvNames.Password]
 		}
 
-		if modifiedFeatures != nil {
-			if modifiedFeature, ok := modifiedFeatures[databaseID]; ok {
-				if modifiedFeature != nil && modifiedFeature.DefaultDatabase != nil {
-					inst.Env[iEnvNames.Database] = *modifiedFeature.DefaultDatabase
+		if options != nil {
+			if modifiedFeature, ok := options[databaseID]; ok {
+				if modifiedFeature != nil && modifiedFeature.DatabaseName != nil {
+					inst.Env[iEnvNames.Database] = *modifiedFeature.DatabaseName
 					continue
 				}
 			}

--- a/apps/containers/core/service/container.go
+++ b/apps/containers/core/service/container.go
@@ -362,7 +362,7 @@ func (s *ContainerService) load(uuid uuid.UUID) error {
 }
 
 func (s *ContainerService) SetDatabases(inst *types.Container, databases map[string]uuid.UUID, modifiedFeature map[string]*types.DatabaseFeature) error {
-	for db, _ := range databases {
+	for db := range databases {
 		if _, ok := inst.Service.Databases[db]; !ok {
 			return types.ErrDatabaseIDNotFound
 		}

--- a/apps/containers/core/types/container.go
+++ b/apps/containers/core/types/container.go
@@ -22,6 +22,7 @@ const (
 var (
 	ErrContainerNotFound     = errors.New("container not found")
 	ErrContainerStillRunning = errors.New("container still running")
+	ErrDatabaseIDNotFound    = errors.New("database id not found")
 )
 
 type Container struct {

--- a/apps/containers/core/types/service.go
+++ b/apps/containers/core/types/service.go
@@ -134,6 +134,10 @@ type DatabaseFeature struct {
 	// The Password to connect to the database. Must be the name
 	// of an environment variable.
 	Password *string `yaml:"password" json:"password"`
+
+	// The DefaultDatabase to connect to the database. Must be the name
+	// of an environment variable.
+	DefaultDatabase *string `yaml:"default-database" json:"database_default"`
 }
 
 type Features struct {

--- a/apps/containers/core/types/service.go
+++ b/apps/containers/core/types/service.go
@@ -252,3 +252,9 @@ type URL struct {
 	// It can be: client, server.
 	Kind string `yaml:"kind" json:"kind"`
 }
+
+type SetDatabasesOptions struct {
+	// The database name to connect to the database. Must be the name
+	// of an environment variable.
+	DatabaseName *string
+}

--- a/apps/containers/handler/container.go
+++ b/apps/containers/handler/container.go
@@ -190,16 +190,16 @@ func (h *ContainerHandler) Patch(c *router.Context) {
 	if body.Databases != nil {
 
 		databases := map[string]uuid.UUID{}
-		modifiedFeatures := map[string]*types3.DatabaseFeature{}
+		options := map[string]*types3.SetDatabasesOptions{}
 
 		for databaseID, container := range body.Databases {
 			databases[databaseID] = container.ContainerID
-			modifiedFeatures[databaseID] = &types3.DatabaseFeature{
-				DefaultDatabase: container.DatabaseName,
+			options[databaseID] = &types3.SetDatabasesOptions{
+				DatabaseName: container.DatabaseName,
 			}
 		}
 
-		err = h.containerService.SetDatabases(inst, databases, modifiedFeatures)
+		err = h.containerService.SetDatabases(inst, databases, options)
 		if err != nil {
 			c.Abort(router.Error{
 				Code:           types3.ErrCodeFailedToSetDatabase,


### PR DESCRIPTION
Feat: Add custom database name support (fixes #12)
- Add DefaultDatabase In feature struct
- Add PatchBodyDatabase struct for PATCH operation supporting custom database_name (can add support alternate username and password )
- Support delete outdated env variable 
- Fix a bug in the write env file operation 