### PR TITLE
Use `docapi` for ssh routes

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -40,3 +40,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-docapi:
+    needs: release
+    name: Generate DocAPI
+    uses: ./.github/workflows/call-docapi.yml

--- a/.github/workflows/call-docapi.yml
+++ b/.github/workflows/call-docapi.yml
@@ -1,0 +1,16 @@
+name: Trigger docapi
+
+on: [workflow_call]
+
+jobs:
+  trigger-docapi:
+    name: Trigger docapi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docapi
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: docapi
+          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -24,3 +24,7 @@ jobs:
   lint:
     name: Lint
     uses: ./.github/workflows/call-lint.yml
+  docapi:
+    name: Generate DocAPI
+    if: github.ref == 'refs/heads/dev'
+    uses: ./.github/workflows/call-docapi.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,8 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  release-docapi:
+    needs: release
+    name: Generate DocAPI
+    uses: ./.github/workflows/call-docapi.yml

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -201,6 +201,19 @@ func initServices(about types.About) {
 }
 
 func initRoutes(about types.About) {
+	// docapi:title Vertex
+	// docapi:description A platform to manage your self-hosted server.
+	// docapi:version 0.0.0
+
+	// docapi:code 200 Success.
+	// docapi:code 201 Created.
+	// docapi:code 204 No content.
+	// docapi:code 400 {Error} Bad request.
+	// docapi:code 404 {Error} Resource not found.
+	// docapi:code 409 {Error} Conflict.
+	// docapi:code 422 {Error} Unprocessable entity.
+	// docapi:code 500 {Error} Internal error.
+
 	r.NoRoute(func(c *gin.Context) {
 		c.JSON(http.StatusNotFound, router.Error{
 			Code:          "resource_not_found",
@@ -240,8 +253,11 @@ func initRoutes(about types.About) {
 
 	sshHandler := handler.NewSshHandler(sshService)
 	ssh := api.Group("/security/ssh")
+	// docapi:route /security/ssh get_ssh_keys
 	ssh.GET("", sshHandler.Get)
+	// docapi:route /security/ssh add_ssh_key
 	ssh.POST("", sshHandler.Add)
+	// docapi:route /security/ssh/{fingerprint} delete_ssh_key
 	ssh.DELETE("/:fingerprint", sshHandler.Delete)
 }
 

--- a/handler/ssh.go
+++ b/handler/ssh.go
@@ -22,6 +22,14 @@ func NewSshHandler(sshService port.SshService) port.SshHandler {
 	}
 }
 
+// docapi:begin get_ssh_keys
+// docapi:method GET
+// docapi:summary Get all SSH keys.
+// docapi:tags ssh
+// docapi:response 200 []PublicKey The list of SSH keys.
+// docapi:response 500
+// docapi:end
+
 func (h *SshHandler) Get(c *router.Context) {
 	keys, err := h.sshService.GetAll()
 	if err != nil {
@@ -39,6 +47,16 @@ func (h *SshHandler) Get(c *router.Context) {
 type AddSSHKeyBody struct {
 	AuthorizedKey string `json:"authorized_key"`
 }
+
+// docapi:begin add_ssh_key
+// docapi:method POST
+// docapi:summary Add an SSH key.
+// docapi:tags ssh
+// docapi:body AddSSHKeyBody The SSH key to add.
+// docapi:response 201
+// docapi:response 400
+// docapi:response 500
+// docapi:end
 
 func (h *SshHandler) Add(c *router.Context) {
 	var body AddSSHKeyBody
@@ -66,6 +84,16 @@ func (h *SshHandler) Add(c *router.Context) {
 
 	c.Status(http.StatusCreated)
 }
+
+// docapi:begin delete_ssh_key
+// docapi:method DELETE
+// docapi:summary Delete an SSH key.
+// docapi:tags ssh
+// docapi:query fingerprint string The fingerprint of the SSH key to delete.
+// docapi:response 204
+// docapi:response 400
+// docapi:response 500
+// docapi:end
 
 func (h *SshHandler) Delete(c *router.Context) {
 	fingerprint := c.Param("fingerprint")


### PR DESCRIPTION
`docapi` is a simple tool that I created to generate API documentation for Vertex: https://github.com/quentinguidee/docapi.

Current tools are not ideal since they require to specify the route path in the handler instead of the router itself. This tool solves this by declaring handlers separately.

The tool generates OpenAPI specifications that we'll be able to reuse for clients and to generate API documentation on the Vertex website.

## Todo

- [x] Generate OpenAPI specs automatically somewhere