### PR TITLE
Fix volume permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 live
 live_kernel
+live_docker
 
 vertex
 vertex-old

--- a/apps/containers/adapter/docker_cli.go
+++ b/apps/containers/adapter/docker_cli.go
@@ -6,7 +6,6 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/vertex-center/vertex/apps/containers/core/port"
@@ -166,20 +165,4 @@ func (a DockerCliAdapter) BuildImage(options types.BuildImageOptions) (dockertyp
 	}
 
 	return a.cli.ImageBuild(context.Background(), reader, buildOptions)
-}
-
-func (a DockerCliAdapter) CreateVolume(options types.CreateVolumeOptions) (types.Volume, error) {
-	vol, err := a.cli.VolumeCreate(context.Background(), volume.CreateOptions{
-		Name: options.Name,
-	})
-	if err != nil {
-		return types.Volume{}, err
-	}
-	return types.Volume{
-		Name: vol.Name,
-	}, nil
-}
-
-func (a DockerCliAdapter) DeleteVolume(name string) error {
-	return a.cli.VolumeRemove(context.Background(), name, true)
 }

--- a/apps/containers/adapter/runner_docker.go
+++ b/apps/containers/adapter/runner_docker.go
@@ -18,11 +18,11 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-connections/nat"
 	"github.com/google/go-containerregistry/pkg/crane"
-	types "github.com/vertex-center/vertex/apps/containers/core/types"
+	"github.com/google/uuid"
+	"github.com/vertex-center/vertex/apps/containers/core/types"
 	"github.com/vertex-center/vertex/config"
 	"github.com/vertex-center/vertex/pkg/log"
 	"github.com/vertex-center/vertex/pkg/router"
-	"github.com/vertex-center/vertex/pkg/storage"
 	"github.com/vertex-center/vertex/pkg/vdocker"
 	"github.com/vertex-center/vlog"
 )
@@ -61,7 +61,6 @@ func (a ContainerRunnerDockerAdapter) Start(inst *types.Container, setStatus fun
 
 		setStatus(types.ContainerStatusBuilding)
 
-		containerPath := a.getPath(*inst)
 		service := inst.Service
 
 		log.Debug("building image", vlog.String("image", imageName))
@@ -70,6 +69,7 @@ func (a ContainerRunnerDockerAdapter) Start(inst *types.Container, setStatus fun
 		var err error
 		var stdout, stderr io.ReadCloser
 		if service.Methods.Docker.Dockerfile != nil {
+			containerPath := a.getContainerPath(inst.UUID)
 			stdout, err = a.buildImageFromDockerfile(containerPath, imageName)
 		} else if service.Methods.Docker.Image != nil {
 			stdout, err = a.buildImageFromName(inst.GetImageNameWithTag())
@@ -194,7 +194,8 @@ func (a ContainerRunnerDockerAdapter) Start(inst *types.Container, setStatus fun
 			if service.Methods.Docker.Volumes != nil {
 				for source, target := range *service.Methods.Docker.Volumes {
 					if !strings.HasPrefix(source, "/") {
-						source, err = filepath.Abs(path.Join(containerPath, "volumes", source))
+						volumePath := a.getVolumePath(inst.UUID)
+						source, err = filepath.Abs(path.Join(volumePath, source))
 					}
 					if err != nil {
 						return
@@ -571,9 +572,17 @@ func (a ContainerRunnerDockerAdapter) readLogs(containerID string) (stdout io.Re
 	return rOut, rErr, nil
 }
 
-func (a ContainerRunnerDockerAdapter) getPath(inst types.Container) string {
-	base := storage.Path
+func (a ContainerRunnerDockerAdapter) getVolumePath(uuid uuid.UUID) string {
+	appPath := a.getAppPath("live_docker")
+	return path.Join(appPath, "volumes", uuid.String())
+}
 
+func (a ContainerRunnerDockerAdapter) getContainerPath(uuid uuid.UUID) string {
+	appPath := a.getAppPath("live")
+	return path.Join(appPath, uuid.String())
+}
+
+func (a ContainerRunnerDockerAdapter) getAppPath(base string) string {
 	// If Vertex is running itself inside Docker, the containers are stored in the Vertex container volume.
 	if vdocker.RunningInDocker() {
 		var containers []types.DockerContainer
@@ -587,7 +596,7 @@ func (a ContainerRunnerDockerAdapter) getPath(inst types.Container) string {
 			for _, c := range containers {
 				// find the docker container that has a volume /live, which is the Vertex container.
 				for _, m := range c.Mounts {
-					if m.Destination == "/live" {
+					if m.Destination == "/"+base {
 						base = m.Source
 					}
 				}
@@ -595,5 +604,5 @@ func (a ContainerRunnerDockerAdapter) getPath(inst types.Container) string {
 		}
 	}
 
-	return path.Join(base, "apps", "vx-containers", inst.UUID.String())
+	return path.Join(base, "apps", "vx-containers")
 }

--- a/apps/containers/adapter/runner_docker.go
+++ b/apps/containers/adapter/runner_docker.go
@@ -41,6 +41,17 @@ func (a ContainerRunnerDockerAdapter) Delete(inst *types.Container) error {
 
 	apiError := router.Error{}
 	err = requests.URL(config.Current.KernelURL()).
+		Pathf("/api/app/vx-containers/docker/container/%s/mounts", inst.UUID.String()).
+		Delete().
+		ErrorJSON(&apiError).
+		Fetch(context.Background())
+
+	if err != nil {
+		log.Error(err, vlog.String("uuid", inst.UUID.String()))
+	}
+
+	apiError = router.Error{}
+	err = requests.URL(config.Current.KernelURL()).
 		Pathf("/api/app/vx-containers/docker/container/%s", id).
 		Delete().
 		ErrorJSON(&apiError).

--- a/apps/containers/app.go
+++ b/apps/containers/app.go
@@ -152,36 +152,33 @@ func (a *App) InitializeKernel(r *router.Group) error {
 
 	dockerHandler := handler.NewDockerKernelHandler(dockerKernelService)
 	docker := r.Group("/docker")
-	// docapi:k route /app/vx-containers/containers vx_containers_kernel_get_containers
+	// docapi:k route /app/vx-containers/docker/containers vx_containers_kernel_get_containers
 	docker.GET("/containers", dockerHandler.GetContainers)
-	// docapi:k route /app/vx-containers/containers vx_containers_kernel_create_container
+	// docapi:k route /app/vx-containers/docker/containers vx_containers_kernel_create_container
 	docker.POST("/container", dockerHandler.CreateContainer)
-	// docapi:k route /app/vx-containers/containers/{id} vx_containers_kernel_delete_container
+	// docapi:k route /app/vx-containers/docker/containers/{id} vx_containers_kernel_delete_container
 	docker.DELETE("/container/:id", dockerHandler.DeleteContainer)
-	// docapi:k route /app/vx-containers/containers/{id}/start vx_containers_kernel_start_container
+	// docapi:k route /app/vx-containers/docker/containers/{id}/start vx_containers_kernel_start_container
 	docker.POST("/container/:id/start", dockerHandler.StartContainer)
-	// docapi:k route /app/vx-containers/containers/{id}/stop vx_containers_kernel_stop_container
+	// docapi:k route /app/vx-containers/docker/containers/{id}/stop vx_containers_kernel_stop_container
 	docker.POST("/container/:id/stop", dockerHandler.StopContainer)
-	// docapi:k route /app/vx-containers/containers/{id}/info vx_containers_kernel_info_container
+	// docapi:k route /app/vx-containers/docker/containers/{id}/info vx_containers_kernel_info_container
 	docker.GET("/container/:id/info", dockerHandler.InfoContainer)
-	// docapi:k route /app/vx-containers/containers/{id}/logs/stdout vx_containers_kernel_logs_stdout_container
+	// docapi:k route /app/vx-containers/docker/containers/{id}/logs/stdout vx_containers_kernel_logs_stdout_container
 	docker.GET("/container/:id/logs/stdout", dockerHandler.LogsStdoutContainer)
-	// docapi:k route /app/vx-containers/containers/{id}/logs/stderr vx_containers_kernel_logs_stderr_container
+	// docapi:k route /app/vx-containers/docker/containers/{id}/logs/stderr vx_containers_kernel_logs_stderr_container
 	docker.GET("/container/:id/logs/stderr", dockerHandler.LogsStderrContainer)
-	// docapi:k route /app/vx-containers/containers/{id}/wait/{cond} vx_containers_kernel_wait_container
+	// docapi:k route /app/vx-containers/docker/containers/{id}/wait/{cond} vx_containers_kernel_wait_container
 	docker.GET("/container/:id/wait/:cond", dockerHandler.WaitContainer)
+	// docapi:k route /app/vx-containers/docker/containers/mounts/{id} vx_containers_kernel_delete_mounts
+	docker.DELETE("/container/:id/mounts", dockerHandler.DeleteMounts)
 
-	// docapi:k route /app/vx-containers/image/{id}/info vx_containers_kernel_info_image
+	// docapi:k route /app/vx-containers/docker/image/{id}/info vx_containers_kernel_info_image
 	docker.GET("/image/:id/info", dockerHandler.InfoImage)
-	// docapi:k route /app/vx-containers/image/pull vx_containers_kernel_pull_image
+	// docapi:k route /app/vx-containers/docker/image/pull vx_containers_kernel_pull_image
 	docker.POST("/image/pull", dockerHandler.PullImage)
-	// docapi:k route /app/vx-containers/image/build vx_containers_kernel_build_image
+	// docapi:k route /app/vx-containers/docker/image/build vx_containers_kernel_build_image
 	docker.POST("/image/build", dockerHandler.BuildImage)
-
-	// docapi:k route /app/vx-containers/volume vx_containers_kernel_create_volume
-	docker.POST("/volume", dockerHandler.CreateVolume)
-	// docapi:k route /app/vx-containers/volume/{name} vx_containers_kernel_delete_volume
-	docker.DELETE("/volume/:name", dockerHandler.DeleteVolume)
 
 	return nil
 }

--- a/apps/containers/core/port/adapters.go
+++ b/apps/containers/core/port/adapters.go
@@ -87,8 +87,5 @@ type (
 		InfoImage(id string) (types.InfoImageResponse, error)
 		PullImage(options types.PullImageOptions) (io.ReadCloser, error)
 		BuildImage(options types.BuildImageOptions) (dockertypes.ImageBuildResponse, error)
-
-		CreateVolume(options types.CreateVolumeOptions) (types.Volume, error)
-		DeleteVolume(name string) error
 	}
 )

--- a/apps/containers/core/port/handlers.go
+++ b/apps/containers/core/port/handlers.go
@@ -55,6 +55,8 @@ type (
 		LogsStderrContainer(c *router.Context)
 		// WaitContainer handles the waiting for a Docker container to reach a certain condition.
 		WaitContainer(c *router.Context)
+		// DeleteMounts handles the deletion of all mounts of a Docker container.
+		DeleteMounts(c *router.Context)
 
 		// InfoImage handles the retrieval of information about a Docker image.
 		InfoImage(c *router.Context)
@@ -62,10 +64,5 @@ type (
 		PullImage(c *router.Context)
 		// BuildImage handles the building of a Docker image.
 		BuildImage(c *router.Context)
-
-		// CreateVolume handles the creation of a Docker volume.
-		CreateVolume(c *router.Context)
-		// DeleteVolume handles the deletion of a Docker volume.
-		DeleteVolume(c *router.Context)
 	}
 )

--- a/apps/containers/core/port/services.go
+++ b/apps/containers/core/port/services.go
@@ -80,12 +80,10 @@ type (
 		LogsStdoutContainer(id string) (io.ReadCloser, error)
 		LogsStderrContainer(id string) (io.ReadCloser, error)
 		WaitContainer(id string, cond types.WaitContainerCondition) error
+		DeleteMounts(uuid string) error
 
 		InfoImage(id string) (types.InfoImageResponse, error)
 		PullImage(options types.PullImageOptions) (io.ReadCloser, error)
 		BuildImage(options types.BuildImageOptions) (vtypes.ImageBuildResponse, error)
-
-		CreateVolume(options types.CreateVolumeOptions) (types.Volume, error)
-		DeleteVolume(name string) error
 	}
 )

--- a/apps/containers/core/service/docker_kernel.go
+++ b/apps/containers/core/service/docker_kernel.go
@@ -1,7 +1,10 @@
 package service
 
 import (
+	"errors"
 	"io"
+	"os"
+	"path"
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/vertex-center/vertex/apps/containers/core/port"
@@ -70,10 +73,11 @@ func (s DockerKernelService) BuildImage(options types.BuildImageOptions) (docker
 	return s.dockerAdapter.BuildImage(options)
 }
 
-func (s DockerKernelService) CreateVolume(options types.CreateVolumeOptions) (types.Volume, error) {
-	return s.dockerAdapter.CreateVolume(options)
-}
-
-func (s DockerKernelService) DeleteVolume(name string) error {
-	return s.dockerAdapter.DeleteVolume(name)
+func (s DockerKernelService) DeleteMounts(uuid string) error {
+	volumesPath := path.Join("live_docker", "apps", "vx-containers", "volumes", uuid)
+	err := os.RemoveAll(volumesPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }

--- a/apps/containers/core/service/docker_kernel_test.go
+++ b/apps/containers/core/service/docker_kernel_test.go
@@ -143,31 +143,6 @@ func (suite *DockerKernelServiceTestSuite) TestBuildImage() {
 	suite.adapter.AssertExpectations(suite.T())
 }
 
-func (suite *DockerKernelServiceTestSuite) TestCreateVolume() {
-	options := types.CreateVolumeOptions{
-		Name: "volume_name",
-	}
-
-	suite.adapter.On("CreateVolume", options).Return(types.Volume{}, nil)
-
-	volume, err := suite.service.CreateVolume(options)
-
-	suite.Require().NoError(err)
-	suite.Equal(types.Volume{}, volume)
-	suite.adapter.AssertExpectations(suite.T())
-}
-
-func (suite *DockerKernelServiceTestSuite) TestDeleteVolume() {
-	name := "volume_name"
-
-	suite.adapter.On("DeleteVolume", name).Return(nil)
-
-	err := suite.service.DeleteVolume(name)
-
-	suite.Require().NoError(err)
-	suite.adapter.AssertExpectations(suite.T())
-}
-
 type MockDockerAdapter struct {
 	mock.Mock
 }
@@ -230,14 +205,4 @@ func (m *MockDockerAdapter) PullImage(options types.PullImageOptions) (io.ReadCl
 func (m *MockDockerAdapter) BuildImage(options types.BuildImageOptions) (dockertypes.ImageBuildResponse, error) {
 	args := m.Called(options)
 	return args.Get(0).(dockertypes.ImageBuildResponse), args.Error(1)
-}
-
-func (m *MockDockerAdapter) CreateVolume(options types.CreateVolumeOptions) (types.Volume, error) {
-	args := m.Called(options)
-	return args.Get(0).(types.Volume), args.Error(1)
-}
-
-func (m *MockDockerAdapter) DeleteVolume(name string) error {
-	args := m.Called(name)
-	return args.Error(0)
 }

--- a/apps/containers/core/types/errors.go
+++ b/apps/containers/core/types/errors.go
@@ -31,8 +31,7 @@ const (
 	ErrCodeFailedToGetImageInfo           router.ErrCode = "failed_to_get_image_info"
 	ErrCodeFailedToPullImage              router.ErrCode = "failed_to_pull_image"
 	ErrCodeFailedToBuildImage             router.ErrCode = "failed_to_build_image"
-	ErrCodeFailedToCreateVolume           router.ErrCode = "failed_to_create_volume"
-	ErrCodeFailedToDeleteVolume           router.ErrCode = "failed_to_delete_volume"
+	ErrCodeFailedToDeleteMounts           router.ErrCode = "failed_to_delete_mounts"
 
 	ErrCodeServiceIdMissing       router.ErrCode = "service_id_missing"
 	ErrCodeServiceNotFound        router.ErrCode = "service_not_found"

--- a/apps/containers/handler/docker_kernel.go
+++ b/apps/containers/handler/docker_kernel.go
@@ -295,6 +295,31 @@ func (h *DockerKernelHandler) WaitContainer(c *router.Context) {
 	c.OK()
 }
 
+// docapi begin vx_containers_kernel_delete_mounts
+// docapi method DELETE
+// docapi summary Delete mounts
+// docapi tags Apps/Containers
+// docapi query id {string} The container uuid.
+// docapi response 200
+// docapi response 500
+// docapi end
+
+func (h *DockerKernelHandler) DeleteMounts(c *router.Context) {
+	id := c.Param("id")
+
+	err := h.dockerService.DeleteMounts(id)
+	if err != nil {
+		c.Abort(router.Error{
+			Code:           types.ErrCodeFailedToDeleteMounts,
+			PublicMessage:  fmt.Sprintf("Failed to delete mounts of %s.", id),
+			PrivateMessage: err.Error(),
+		})
+		return
+	}
+
+	c.OK()
+}
+
 // docapi begin vx_containers_kernel_info_image
 // docapi method GET
 // docapi summary Get image info
@@ -414,58 +439,4 @@ func (h *DockerKernelHandler) BuildImage(c *router.Context) {
 		}
 		return true
 	})
-}
-
-// docapi begin vx_containers_kernel_create_volume
-// docapi method POST
-// docapi summary Create volume
-// docapi tags Apps/Containers
-// docapi body {CreateVolumeOptions} The options to create the volume.
-// docapi response 200 {Volume} The volume.
-// docapi response 500
-// docapi end
-
-func (h *DockerKernelHandler) CreateVolume(c *router.Context) {
-	var options types.CreateVolumeOptions
-	err := c.ParseBody(&options)
-	if err != nil {
-		return
-	}
-
-	vol, err := h.dockerService.CreateVolume(options)
-	if err != nil {
-		c.Abort(router.Error{
-			Code:           types.ErrCodeFailedToCreateVolume,
-			PublicMessage:  fmt.Sprintf("Failed to create volume %s.", options.Name),
-			PrivateMessage: err.Error(),
-		})
-		return
-	}
-
-	c.JSON(vol)
-}
-
-// docapi begin vx_containers_kernel_delete_volume
-// docapi method DELETE
-// docapi summary Delete volume
-// docapi tags Apps/Containers
-// docapi query name {string} The volume name.
-// docapi response 200
-// docapi response 500
-// docapi end
-
-func (h *DockerKernelHandler) DeleteVolume(c *router.Context) {
-	name := c.Param("name")
-
-	err := h.dockerService.DeleteVolume(name)
-	if err != nil {
-		c.Abort(router.Error{
-			Code:           types.ErrCodeFailedToDeleteVolume,
-			PublicMessage:  fmt.Sprintf("Failed to delete volume %s.", name),
-			PrivateMessage: err.Error(),
-		})
-		return
-	}
-
-	c.OK()
 }

--- a/apps/monitoring/adapter/metrics_prometheus.go
+++ b/apps/monitoring/adapter/metrics_prometheus.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/vertex-center/vertex/config"
 	"github.com/vertex-center/vertex/pkg/log"
-	"github.com/vertex-center/vertex/pkg/storage"
 	"github.com/vertex-center/vlog"
 	"gopkg.in/yaml.v3"
 )
@@ -56,7 +55,7 @@ func NewMetricsPrometheusAdapter() *PrometheusAdapter {
 }
 
 func (a *PrometheusAdapter) ConfigureContainer(uuid uuid.UUID) error {
-	dir := path.Join(storage.Path, "apps", "vx-containers", uuid.String(), "volumes", "config")
+	dir := path.Join("live_docker", "apps", "vx-containers", "volumes", uuid.String(), "config")
 	p := path.Join(dir, "prometheus.yml")
 
 	err := os.MkdirAll(dir, 0755)

--- a/apps/monitoring/core/service/metrics.go
+++ b/apps/monitoring/core/service/metrics.go
@@ -33,7 +33,9 @@ func (s *MetricsService) GetMetrics() []types.Metric {
 
 // ConfigureCollector will configure a container to monitor the metrics of Vertex.
 func (s *MetricsService) ConfigureCollector(inst *containerstypes.Container) error {
-	return s.adapter.ConfigureContainer(inst.UUID)
+	// TODO: Enable again, but permissions are not set correctly
+	// return s.adapter.ConfigureContainer(inst.UUID)
+	return nil
 }
 
 func (s *MetricsService) ConfigureVisualizer(inst *containerstypes.Container) error {


### PR DESCRIPTION
This PR tries to fix #88.

## The problem

Currently, there are two directories:

- `live`: With the same permissions as `vertex`
- `live_kernel`: With the same permissions as `vertex-kernel`

However, Docker has permissions that varies. On some setup, Vertex runs as root, and its files and mounts will be made as root. Sometimes, it is made with the user permissions. So we cannot put them in `live` or `live_kernel` without having issues in both.

## The solution

This PR adds a third folder:

- `live_docker`: With the same permissions as Docker

This folder is made by docker and managed by docker. When we need to delete a mount, we delete it with `vertex-kernel` which has all the permissions.

**NOTE:** This causes highly breaking changes, that can't be migrated automatically.