### PR TITLE
Service: Use ENV instead of default values

### DIFF
--- a/apps/containers/adapter/runner_docker.go
+++ b/apps/containers/adapter/runner_docker.go
@@ -187,7 +187,7 @@ func (a ContainerRunnerDockerAdapter) Start(inst *types.Container, setStatus fun
 
 				for in, out := range *service.Methods.Docker.Ports {
 					for _, e := range service.Env {
-						if e.Type == "port" && e.Default == out {
+						if e.Type == "port" && e.Name == out {
 							out = inst.Env[e.Name]
 							all = append(all, out+":"+in)
 							break

--- a/apps/containers/core/types/service_test.go
+++ b/apps/containers/core/types/service_test.go
@@ -1,0 +1,72 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+)
+
+type ServiceTestSuite struct {
+	suite.Suite
+}
+
+func TestServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(ServiceTestSuite))
+}
+
+func (suite *ServiceTestSuite) TestServiceUpgrade() {
+	s := ServiceV1{
+		ServiceVersioning: ServiceVersioning{
+			Version: 1,
+		},
+		Env: []ServiceEnv{
+			{
+				Type:    "port",
+				Name:    "PORT_22",
+				Default: "22",
+			},
+			{
+				Type:    "port",
+				Name:    "PORT_80",
+				Default: "80",
+			},
+		},
+		URLs: []URL{
+			{
+				Port: "22",
+			},
+			{
+				Port: "80",
+			},
+		},
+		Methods: ServiceMethods{
+			Docker: &ServiceMethodDocker{
+				Ports: &map[string]string{
+					"22": "22",
+					"80": "80",
+				},
+			},
+		},
+	}
+
+	bytes, err := yaml.Marshal(&s)
+	suite.Require().NoError(err)
+
+	var service Service
+	err = yaml.Unmarshal(bytes, &service)
+	suite.Require().NoError(err)
+	suite.Equal(2, int(service.Version))
+	suite.Equal(&map[string]string{
+		"22": "PORT_22",
+		"80": "PORT_80",
+	}, service.Methods.Docker.Ports)
+	suite.Equal([]URL{
+		{
+			Port: "PORT_22",
+		},
+		{
+			Port: "PORT_80",
+		},
+	}, service.URLs)
+}


### PR DESCRIPTION
This new version of service.yaml simplified the process of defining ports. Instead of relying on the default value of a port, it now uses the variable name.

```diff
- version: 1
+ version: 2

  urls:
    - name: SonarQube
-     port: 9000
+     port: PORT
      kind: client

  methods:
    docker:
      ports:
-       9000: 9000
+       9000: PORT
```